### PR TITLE
replace resource by endpoint when appropriate

### DIFF
--- a/DataLink.tex
+++ b/DataLink.tex
@@ -14,7 +14,7 @@
        {Laurent Michel}
 \author[http://www.ivoa.net/twiki/bin/view/IVOA/MarkusDemleitner]
        {Markus Demleitner}
-\author[http://www.ivoa.net/twiki/bin/view/IVOA/MarkusDemleitner]
+\author[http://www.ivoa.net/twiki/bin/view/IVOA/MarkTaylor]
        {Mark Taylor}
 \editor[http://www.ivoa.net/twiki/bin/view/IVOA/PatrickDowler]
        {Patrick Dowler}

--- a/DataLink.tex
+++ b/DataLink.tex
@@ -66,16 +66,18 @@ infrastructure that enable VO applications.
 \section{Introduction}
 
 This specification defines mechanisms for connecting metadata about
-discovered datasets to the data, related data products, and web services
-that can act upon the data.
+discovered VO items to  related data products, and web services
 
 The {\em links\/} web service capability is a web service capability
 for drilling
-down from a discovered dataset identifier (typically an IVOA publisher
-dataset identifier) to find details about the data files that can be
+down from a discovered item such as an identifier,
+a source in a catalog or any other data item. In the first case (typically an IVOA publisher dataset identifier) it allows
+ to find details about the data files that can be
 downloaded, alternate representations of the data that are available, and
-services that can act upon the data (usually without having to download
-the entire dataset). The expected usage is for DAL (Data Access Layer)
+services that can act upon these data (usually without having to download
+the entire dataset). 
+In the latter cases it allows to associate metadata, images, cubes, spectra, timeseries or ancillary data to a source in the sky or other kind of time.
+The expected usage for datasets is for DAL (Data Access Layer)
 data discovery services (e.g.\ a TAP service \citep{2010ivoa.spec.0327D}
 with the ObsCore \citep{2017ivoa.spec.0509L} data
 model or one of the simple DAL services) to provide an identifier that
@@ -93,16 +95,12 @@ service metadata tells the client how to invoke a service and, for those
 registered in an IVOA registry, how to lookup additional information
 about the service. The service provider can use this mechanism to tell
 clients about services that can be invoked to access the discovered
-dataset in some way: get additional metadata, download the data, or
+item in some way: get additional metadata, download the data, or
 invoke services that act upon the data files. These services may be
 IVOA standard services or custom services from the data providers. The
 current version provides no way to describe the output of a service,
 but this may be added in a future (minor) revision of this specification.
 
-We expect that the {\em service descriptor resource\/}
-mechanism will be the primary way that clients will find and
-use the {\em links\/} capability from data discovery
-responses.
 
 
 \subsection{The Role in the IVOA Architecture}
@@ -257,6 +255,13 @@ another DataLink service in the initial DataLink response (e.g.\ recursive
 DataLink). This service link would be described with both a service type
 (as in \ref{sec:useStandard}) and content type.
 
+\subsubsection{Datasets linked to an astronomical source}
+
+There are  a lot of catalogs of astronomical sources made available using VO services such as ConeSearch \citep{2008ivoa.specQ0222P} or TAP services. For some catalogs “associated data” are available. These data include images from which sources have been extracted, or imaging the object in  case of extended objects, as well as additional observations such as Spectra or Time Series of the source and even spectral cubes and Time Series of images for extended or varying objects. The \blinks  response obtained for the source id can allow to easilly retrieve all these associated data in one shot.
+
+\subsubsection{Metadata and data related to provenance entities}
+
+The IVOA Provenance datamodel \citep{pr:provdm} represents metadata tracing  the history of data. This information can be retrieved through ProvTAP \citep{iwd:provtap} or ProvSAP \citep{iwd:provsap}  DAL services.  The Entity instances represent  the state of the data items between various steps of the data processing flow. “Entities” can be hooked to lists of real datasets retrieval and previews, or Obscore, SimDM and SSA metadata describing them  using the \blinks endpoint.
 
 \section{Resources}
 

--- a/DataLink.tex
+++ b/DataLink.tex
@@ -14,8 +14,6 @@
        {Laurent Michel}
 \author[http://www.ivoa.net/twiki/bin/view/IVOA/MarkusDemleitner]
        {Markus Demleitner}
-\author[http://www.ivoa.net/twiki/bin/view/IVOA/MarkTaylor]
-       {Mark Taylor}
 \editor[http://www.ivoa.net/twiki/bin/view/IVOA/PatrickDowler]
        {Patrick Dowler}
 
@@ -278,7 +276,7 @@ table below.
 \begin{center}
 \begin{tabular}{|l|l|l|}
 \sptablerule
-{\bf resource type} & {\bf resource name} & {\bf required} \\
+{\bf endpoint type} & {\bf endpoint name} & {\bf required} \\
 \sptablerule
 \blinks             & service specific    & yes            \\
 VOSI-availability   & /availability       & yes            \\
@@ -287,19 +285,19 @@ VOSI-capabilities   & /capabilities       & yes            \\
 \end{tabular}
 \end{center}
 
-A standalone DataLink service must have at least one \blinks\ resource;
-it could have multiple \blinks\ resources (e.g.\ to support alternate
-authentication schemes). Alternatively, the \blinks\ resource may be
+A standalone DataLink service must have at least one \blinks\ endpoint;
+it could have multiple \blinks\ endpoints (e.g.\ to support alternate
+authentication schemes). Alternatively, the \blinks\ endpoint may be
 embedded in another web service, in which case the VOSI-capabilities
 resource of that service would also describe the \blinks\ capability.
 
 
-\subsection{\blinks\ resource}
+\subsection{\blinks\ endpoint}
 \label{sec:linksResource}
 
-The \blinks\ resource is a synchronous web service resource that conforms
+The \blinks\ endpoint is a synchronous web service resource that conforms
 to the DALI-sync description. The implementer is free to name this
-resource however they like as long as the \blinks\ resource is a sibling
+resource however they like as long as the \blinks\ endpoint is a sibling
 of the VOSI resources; this restriction allows a client to construct
 the URL to VOSI resources from any \blinks\ URL and thus discover other
 capabilities or check the availablity if there is a failure. For example,
@@ -358,7 +356,7 @@ TABLEDATA serialization; services must support this format. Clients
 that want to get the standard (VOTable) output format should simply
 ignore this parameter.
 
-To comply with this standard, a \blinks\ resource only needs to strip
+To comply with this standard, a \blinks\ endpoint only needs to strip
 off MIME type parameters and understand the following:
 \begin{itemize}
   \item no RESPONSEFORMAT
@@ -373,15 +371,15 @@ the DALI specification if they chose any formats described there.
 
 \subsection{Availability: VOSI-availability}
 
-A DataLink web service must have a VOSI-availability resource,
+A DataLink web service must have a VOSI-availability endpoint,
 as defined by DALI and VOSI.
 
 
 \subsection{Capabilities: VOSI-capabilities}
 
 A standalone DataLink web service must have a
-VOSI-capabilities resource as defined by DALI and VOSI.
-The standardID for the \blinks\ resource is
+VOSI-capabilities endpoint as defined by DALI and VOSI.
+The standardID for the \blinks\ endpoint is
 \begin{verbatim}
    ivo://ivoa.net/std/DataLink#links-1.0
 \end{verbatim}
@@ -416,7 +414,7 @@ and does not require a registry extension schema:
 </vosi:capabilities>
 \end{verbatim}
 
-Multiple capability elements for the \blinks\ resource may be included;
+Multiple capability elements for the \blinks\ endpoint may be included;
 this is typically used if they differ in protocol (http vs.\ https)
 and/or authentication requirements.
 
@@ -427,7 +425,7 @@ describe all the capabilities of that service, including \blinks.
 
 \section{\blinks\ Response}
 
-All responses from the \blinks\ resource follow the rules for DALI-sync
+All responses from the \blinks\ endpoint follow the rules for DALI-sync
 resources, except that the \blinks\ response allows for error
 messages for individual input identifier values.
 
@@ -455,7 +453,7 @@ Services may include other MIME type parameters in the response.
 \subsection{List of Links}
 \label{sec:listOfLinks}
 
-The list of links that is returned by the \blinks\ resource can be
+The list of links that is returned by the \blinks\ endpoint can be
 represented as a table with the following columns:
 \begin{table}[h]
 \begin{center}

--- a/DataLink.tex
+++ b/DataLink.tex
@@ -14,6 +14,8 @@
        {Laurent Michel}
 \author[http://www.ivoa.net/twiki/bin/view/IVOA/MarkusDemleitner]
        {Markus Demleitner}
+\author[http://www.ivoa.net/twiki/bin/view/IVOA/MarkusDemleitner]
+       {Mark Taylor}
 \editor[http://www.ivoa.net/twiki/bin/view/IVOA/PatrickDowler]
        {Patrick Dowler}
 
@@ -66,18 +68,16 @@ infrastructure that enable VO applications.
 \section{Introduction}
 
 This specification defines mechanisms for connecting metadata about
-discovered VO items to  related data products, and web services
+discovered datasets to the data, related data products, and web services
+that can act upon the data.
 
 The {\em links\/} web service capability is a web service capability
 for drilling
-down from a discovered item such as an identifier,
-a source in a catalog or any other data item. In the first case (typically an IVOA publisher dataset identifier) it allows
- to find details about the data files that can be
+down from a discovered dataset identifier (typically an IVOA publisher
+dataset identifier) to find details about the data files that can be
 downloaded, alternate representations of the data that are available, and
-services that can act upon these data (usually without having to download
-the entire dataset). 
-In the latter cases it allows to associate metadata, images, cubes, spectra, timeseries or ancillary data to a source in the sky or other kind of time.
-The expected usage for datasets is for DAL (Data Access Layer)
+services that can act upon the data (usually without having to download
+the entire dataset). The expected usage is for DAL (Data Access Layer)
 data discovery services (e.g.\ a TAP service \citep{2010ivoa.spec.0327D}
 with the ObsCore \citep{2017ivoa.spec.0509L} data
 model or one of the simple DAL services) to provide an identifier that
@@ -95,12 +95,16 @@ service metadata tells the client how to invoke a service and, for those
 registered in an IVOA registry, how to lookup additional information
 about the service. The service provider can use this mechanism to tell
 clients about services that can be invoked to access the discovered
-item in some way: get additional metadata, download the data, or
+dataset in some way: get additional metadata, download the data, or
 invoke services that act upon the data files. These services may be
 IVOA standard services or custom services from the data providers. The
 current version provides no way to describe the output of a service,
 but this may be added in a future (minor) revision of this specification.
 
+We expect that the {\em service descriptor resource\/}
+mechanism will be the primary way that clients will find and
+use the {\em links\/} capability from data discovery
+responses.
 
 
 \subsection{The Role in the IVOA Architecture}
@@ -255,13 +259,6 @@ another DataLink service in the initial DataLink response (e.g.\ recursive
 DataLink). This service link would be described with both a service type
 (as in \ref{sec:useStandard}) and content type.
 
-\subsubsection{Datasets linked to an astronomical source}
-
-There are  a lot of catalogs of astronomical sources made available using VO services such as ConeSearch \citep{2008ivoa.specQ0222P} or TAP services. For some catalogs “associated data” are available. These data include images from which sources have been extracted, or imaging the object in  case of extended objects, as well as additional observations such as Spectra or Time Series of the source and even spectral cubes and Time Series of images for extended or varying objects. The \blinks  response obtained for the source id can allow to easilly retrieve all these associated data in one shot.
-
-\subsubsection{Metadata and data related to provenance entities}
-
-The IVOA Provenance datamodel \citep{pr:provdm} represents metadata tracing  the history of data. This information can be retrieved through ProvTAP \citep{iwd:provtap} or ProvSAP \citep{iwd:provsap}  DAL services.  The Entity instances represent  the state of the data items between various steps of the data processing flow. “Entities” can be hooked to lists of real datasets retrieval and previews, or Obscore, SimDM and SSA metadata describing them  using the \blinks endpoint.
 
 \section{Resources}
 


### PR DESCRIPTION
DataLink 1.0 made extensive use of the term "resource" to most often designate "endpoints". We will replace resource by "endpoint" when appropriate. Issue #11