### PR TITLE
complete rewriting of self-describing services subsection

### DIFF
--- a/DataLink.tex
+++ b/DataLink.tex
@@ -1061,57 +1061,50 @@ used to call the service.
 A service may include a service descriptor that describes itself with
 its normal output. This usage is comparable to prototype work on S3
 (see \citet{note:s3})
-and when combined with calling a service with no input parameters
-(e.g.\ as allowed in \ref{sec:resourceId})
-will make it easy for clients to obtain a
-description of both standard and custom features.
+and will make it easy for clients to obtain a
+description of both standard and custom features (eg PARAMETER Options or specific endpoints for the resource) it gives ranges or options of all accepted parameters. When combined with calling a service with some of the required parameters only (eg an ID)  the response may give defaults specific to the resource identified or selected  by these parameters.
 
-The output of a \blinks\ capability with no input ID would include the
-self-describing service descriptor and an empty results table:
+
+
 \begin{verbatim}
-   <RESOURCE type="meta" utype="adhoc:service" name="this">
-     <PARAM name="standardID" datatype="char" arraysize="*"
-            value="ivo://ivoa.net/std/DataLink#links-1.0" />
-     <PARAM name="accessURL" datatype="char" arraysize="*"
-            value="http://example.com/mylinks" />
-     <GROUP name="inputParams">
-       <PARAM name="ID" datatype="char" arraysize="*"
-              value="" ref="primaryID"/>
-     </GROUP>
-   </RESOURCE>
-   <RESOURCE type="results">
-     <TABLE>
-       <FIELD name="ID" datatype="char" arraysize="*"
-              ucd="meta.id;meta.main" />
-       <FIELD name="access_url" datatype="char" arraysize="*"
-              ucd="meta.ref.url" />
-       <FIELD name="service_def" datatype="char" arraysize="*"
-              ucd="meta.ref" />
-       <FIELD name="error_message" datatype="char" arraysize="*"
-              ucd="meta.code.error" />
-       <FIELD name="semantics" datatype="char" arraysize="*"
-              ucd="meta.code" />
-       <FIELD name="description" datatype="char" arraysize="*"
-              ucd="meta.note" />
-       <FIELD name="content_type" datatype="char" arraysize="*"
-              ucd="meta.code.mime" />
-       <FIELD name="content_length" datatype="long" unit="byte"
-              ucd="phys.size;meta.file" />
-       <DATA> <TABLEDATA/> </DATA>
-     </TABLE>
-   </RESOURCE>
+<RESOURCE type=”meta” utype=”adhoc:service” ID=”PwL” name=”Power Law fitting”>
+
+    <DESCRIPTION>Apply a power law model on a XMM-Newton EPIC spectrum </DESCRIPTION>	
+	<PARAM name="accessURL" datatype="char" arraysize="*" value="http://obs-he-lm:8888/3XMM/fitmodelonspectrum& model=powlaw" />
+   <GROUP name=”inputParams”>
+      <PARAM name=”oid” datatype=”char” arraysize=”*” 
+        value=”1160803203386703876” unit =”none” >
+         <DESCRIPTION>Spectrum internal ID in the database </DESCRIPTION>
+      </PARAM>
+      <PARAM name=”binSize” ucd=”spect.binSize” datatype=”int” unit=”none” value=”10” >
+         <DESCRIPTION>Number of counts per bin</DESCRIPTION>
+         <VALUES>
+             <OPTION value=”1” />
+             <OPTION value=”5” />
+             <OPTION value=”10” />
+             <OPTION value=”20” />
+             <OPTION value=”50” />
+         </VALUES>
+       </PARAM>
+      <PARAM name=”nh” ucd=”phys.abund.X” datatype=”float” unit=”1e22cm-2” value=”0.01” >
+         <DESCRIPTION>Galactical NH</DESCRIPTION>
+         <VALUES>
+         <MIN value=”0” />
+             <MAX value=”1” />
+         </VALUES>
+       </PARAM>
+      <PARAM name=”alpha” ucd=”meta.code;spect.index” datatype=”float” unit=”none” value=”1.7” >
+         <DESCRIPTION>Photon index of power law</DESCRIPTION>
+         <VALUES>
+             <MIN value=”1” />
+             <MAX value=”9” />
+         </VALUES>
+       </PARAM>
+   </GROUP>
+</RESOURCE>
 \end{verbatim}
 
-In the above example we give the self-describing service descriptor a
-name attribute with the value ``this'' to indicate the self-describing
-nature. This convention would make finding the self-description
-unambiguous in cases where (i) the output also contained other service
-descriptors and (ii) the caller could not infer which descriptor was
-the self-describing one from the standardID (because it is optional
-and not present for custom services and because they might just have a
-URL). Even trying to match the URL that was used with the accessURL in
-the descriptors is likely to be unreliable (e.g.\ if providers use HTTP
-redirects to make old URLs work when service deployment changes).
+In the above example the oid parameter is repeating the value given in the call of the service. The OPTIONS and ranges given for the three other parameters are restricted and adpated to the spectrum so identified.  If the service were called without any parameter the oid would have been free and the ranges and options of the three other parameters would have been valid for the whole service.
 
 
 \section{Changes}


### PR DESCRIPTION
Self-describing services (in case of empty requests) is more intended for SODA-like services or non- standard services than for SIAP. It is proposed to change the example. In addition the self- description can also be used for incomplete requests (and adapt to the available PARAM values). This is related to issue #24