### PR TITLE
Add little recognition section using LINK content-type

### DIFF
--- a/DataLink.tex
+++ b/DataLink.tex
@@ -1124,7 +1124,7 @@ In the above example the oid parameter is repeating the value given in the call 
 \section{New “datalink” content-type for the LINK element in VOTable}
 
 
-When providing a column with URLs, for example outside DAL service responses or when service descriptors  are not defined, if all the URLs are to a DataLink "links" endpoint, then the preferred approach is to add a LINKS element with the content type defined in section \ref{sec:mime}. If some values are to a "links" endpoint and others to different content types (e.g. single file download), then the VOTable would need a second column to convey the content type (see Appendix for details). 
+When providing a column with URLs, for example outside DAL service responses or when service descriptors  are not defined, if all the URLs are to a DataLink "links" endpoint, then the preferred approach is to add a LINKS element with the content type defined in section for \ref{sec:mime}. If some values are to a "links" endpoint and others to different content types (e.g. single file download), then the VOTable would need a second column to convey the content type (see Appendix for details). 
 
 \begin{verbatim} 
 <FIELD name="bla" datatype="char" arraysize="*" utype="Access.reference" ucd="meta.url" > 

--- a/DataLink.tex
+++ b/DataLink.tex
@@ -763,7 +763,7 @@ contains the query result.
 
 To describe an associated service, the VOTable would also
 contain one or more resources with attribute \attval{type}{meta} and
-\attval{utype}{adhoc:service}.
+\attval{utype}{adhoc:service} (or \attval{utype}{adhoc:this} in case of a Self-Describing service -see below \ref{selfDescribing}).
 A resource of this type has no tabular data,
 but may include a rich set of metadata. The utype attribute makes it
 easy for clients to find the RESOURCE elements that describe services.
@@ -1074,7 +1074,11 @@ used to call the service.
 \label{sec:selfDescribing}
 
 A service may include a service descriptor that describes itself with
-its normal output. This usage is comparable to prototype work on S3
+its normal output. In that case the utype "adhoc:this" indicates the self-describing
+nature of the service descriptor. This convention would make finding the self-description
+unambiguous in cases where the output also contained other service
+descriptors.
+   This usage is comparable to prototype work on S3
 (see \citet{note:s3})
 and will make it easy for clients to obtain a
 description of both standard and custom features (eg PARAMETER Options or specific endpoints for the resource) it gives ranges or options of all accepted parameters. When combined with calling a service with some of the required parameters only (eg an ID)  the response may give defaults specific to the resource identified or selected  by these parameters.
@@ -1082,7 +1086,7 @@ description of both standard and custom features (eg PARAMETER Options or specif
 
 
 \begin{verbatim}
-<RESOURCE type=”meta” utype=”adhoc:service” ID=”PwL” name=”Power Law fitting”>
+<RESOURCE type=”meta” utype=”adhoc:this” ID=”PwL” name=”Power Law fitting”>
 
     <DESCRIPTION>Apply a power law model on a XMM-Newton EPIC spectrum </DESCRIPTION>	
 	<PARAM name="accessURL" datatype="char" arraysize="*" value="http://obs-he-lm:8888/3XMM/fitmodelonspectrum& model=powlaw" />

--- a/DataLink.tex
+++ b/DataLink.tex
@@ -1133,19 +1133,6 @@ When providing a column with URLs, for example outside DAL service responses or 
 </FIELD>
 \end{verbatim}
 
-\section{New “datalink” content-type for the LINK element in VOTable}
-
-Beside the cases where  \blinks URLs are retrievied from standard DAL services responses or service descriptors,  if a FIELD contains an URL retrieving a \blinks  response at each row it is easy to tell this to the client using the content-type attribute of an included LINK element, as long as the content-type  “application/x-votable+xml;content=datalink” is provided. (see Appendix)
-
-\begin{verbatim} 
-<FIELD name="bla" datatype="char" arraysize="*"
-       [utype="Access.reference" ucd="meta.url" ]> 
-  <LINK content-type="application/x-votable+xml;content=datalink" title="DataLink" /> 
-  <DESCRIPTION> bla bla bla </DESCRIPTION> 
-</FIELD>
-\end{verbatim}
-
-
 
 \section{Changes}
 

--- a/DataLink.tex
+++ b/DataLink.tex
@@ -1121,6 +1121,18 @@ description of both standard and custom features (eg PARAMETER Options or specif
 
 In the above example the oid parameter is repeating the value given in the call of the service. The OPTIONS and ranges given for the three other parameters are restricted and adpated to the spectrum so identified.  If the service were called without any parameter the oid would have been free and the ranges and options of the three other parameters would have been valid for the whole service.
 
+\section{New “datalink” content-type for the LINK element in VOTable}
+
+
+When providing a column with URLs, for example outside DAL service responses or when service descriptors  are not defined, if all the URLs are to a DataLink "links" endpoint, then the preferred approach is to add a LINKS element with the content type defined in section \ref{sec:mime}. If some values are to a "links" endpoint and others to different content types (e.g. single file download), then the VOTable would need a second column to convey the content type (see Appendix for details). 
+
+\begin{verbatim} 
+<FIELD name="bla" datatype="char" arraysize="*" utype="Access.reference" ucd="meta.url" > 
+  <LINK content-type="application/x-votable+xml;content=datalink" title="DataLink" /> 
+  <DESCRIPTION> bla bla bla </DESCRIPTION> 
+</FIELD>
+\end{verbatim}
+
 
 \section{Changes}
 


### PR DESCRIPTION
Current spec allows two ways to recognize an URL as a links endpoint in a table. Many data providers are reluctant to deploy these mecahnisms outside the DAL discovery services. A simpler mechanism base on the VOTable LINK element could be used by adding "application/x-votable+xml;content=datalink" in the content-type attribute of the link element . Related to issue #29