### PR TITLE
adding possibility of completing mime-type by dataproduct_type parameter

### DIFF
--- a/DataLink.tex
+++ b/DataLink.tex
@@ -568,6 +568,8 @@ For recursive DataLink links, the content\_type value should
 be as specified in section \ref{sec:mime}.
 This field may be null (blank) if the value is unknown.
 
+In various usecases the link delivers a dataproduct. In order to tell the client which dataproduct type it will receive by calling the link, the mime-type may be completed by a parameter called dataproduct\_type (for example a content\_type "application/fits;dataproduct\_type=image" would state for an image in fits format). This parameter list of admitted values is currently  identical to the dataproduct\_type value list in ObsCore. It will move to the dataproduct\_type vocabulary managed by the semantics Working Group when this one will be available.     
+
 
 \subsubsection{content\_length}
 

--- a/DataLink.tex
+++ b/DataLink.tex
@@ -568,7 +568,15 @@ For recursive DataLink links, the content\_type value should
 be as specified in section \ref{sec:mime}.
 This field may be null (blank) if the value is unknown.
 
-In various usecases the link delivers a dataproduct. In order to tell the client which dataproduct type it will receive by calling the link, the mime-type may be completed by a parameter called dataproduct\_type (for example a content\_type "application/fits;dataproduct\_type=image" would state for an image in fits format). This parameter list of admitted values is currently  identical to the dataproduct\_type value list in ObsCore. It will move to the dataproduct\_type vocabulary managed by the semantics Working Group when this one will be available.     
+In various usecases the link delivers a dataproduct. In order to tell
+the client which dataproduct type it will receive by calling the link,
+the mime-type SHOULD be completed by a parameter called dataproduct\_type
+For example a content\_type "application/fits;dataproduct\_type=image"
+is strongly encouraged to foster appropriate behavior of the client 
+when receiving an image in fits format). This parameter list of admitted
+values is currently  identical to the dataproduct\_type value list in ObsCore.
+It must stay consistent with the IVOA vocabulary 
+\url{http://www.ivoa.net/rdf/dataproduct\_type} 
 
 
 \subsubsection{content\_length}

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ DOCNAME = DataLink
 DOCVERSION = 1.1
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2020-02-16
+DOCDATE = 2020-05-05
 
 # What is it you're writing: NOTE, WD, PR, REC, PEN, or EN
-DOCTYPE = REC
+DOCTYPE = WD
 
 # An e-mail address of the person doing the submission to the document
 # repository (can be empty until a make upload is being made)


### PR DESCRIPTION
The pull request adds in the content_type subsection the possibility to add a parameter in the mime-type in order to type the dataproduct retrieved by the link. This is related to issue #42. the proposal is to uses the parameter "dataproduct_type" and to reuse standard lists of values (for that, ObsCore, Vocabulary WG)