### PR TITLE
Not supplying ID is not an error

### DIFF
--- a/DataLink.tex
+++ b/DataLink.tex
@@ -768,8 +768,8 @@ output in other formats.
 \subsection{Errors}
 
 The error handling specified for DALI-sync resources applies
-to service failure (where no links can be generated) and to the usage
-error where no ID parameter is specified. Services should return the
+to service failure (where no links can be generated).
+Services should return the
 document format requested by the client (see \ref{sec:responseformat}).
 For the standard
 output format (VOTable) the error document \rfcmust\ also be VOTable.


### PR DESCRIPTION
Remove text indicating that failure to supply an ID is a {links} error. Required for consistency with section 2.1.1.

See issue #95.