### PR TITLE
Editorial changes after RFC review

### DIFF
--- a/DataLink.tex
+++ b/DataLink.tex
@@ -578,7 +578,10 @@ an ID to the descriptor.
 
 The error\_message column is used when no access\_url or service\_def can be generated for
 an input identifier. If an error\_message is included in the output, the
-ID and semantics values \rfcmust\ be provided as usual. From version 1.1 of this standard,
+ID and semantics values \rfcmust\ be provided as usual; in particular,
+the value in the semantics column should reflect the semantics of the
+link that could not be produced.
+From version 1.1 of this standard,
 services \rfcmay\  provide values in other fields or leave them null (as was required in 1.0).
 
 For example, if an ID value is unrecognized by the service, it would normally provide the

--- a/DataLink.tex
+++ b/DataLink.tex
@@ -81,8 +81,8 @@ for drilling
 down from a discovered data item such as an identifier,
 a source in a catalog or any other data item. In the first case
 (typically an IVOA publisher dataset identifier) it allows
-to find details about the data files that can be
-downloaded, alternate representations of the data that are available, and
+clients to find ancillary resources like progenitors, derived data
+products, or alternate representations of the data, and
 services that can act upon the data (usually without having to download
 the entire dataset). The expected usage is for DAL (Data Access Layer)
 data discovery services (e.g.\ a TAP service \citep{2010ivoa.spec.0327D}
@@ -270,8 +270,8 @@ DataLink). This service link would be described with both a service type
 \label{sec:useSource}
 
 There are  a lot of catalogs of astronomical sources made available
-using VO services such as ConeSearch \citep{2008ivoa.specQ0222P} or TAP
-services. For some catalogs ``associated data'' are available. These
+using VO standards such as ConeSearch \citep{2008ivoa.specQ0222P} or
+TAP.  For some catalogs ``associated data'' are available. These
 data include images from which sources have been extracted, or imaging the
 object in  case of extended objects, as well as additional observations
 such as Spectra or Time Series of the source and even spectral cubes
@@ -370,8 +370,8 @@ giving a capability with a standardID of
 \begin{verbatim}
    ivo://ivoa.net/std/DataLink#links-1.0
 \end{verbatim}
-Note this is applicable to endpoints following any version 1.*
-of the DataLink standard, to avoid backward compatibility problems.
+Note that this (minor-versioned) URI is applicable to endpoints following any version 1.*
+of the DataLink standard.
 
 This specification does not constrain the capability type used in such
 declarations.  The access URL of the \blinks\ endpoint \rfcmust\ be given in a
@@ -581,10 +581,10 @@ an input identifier. If an error\_message is included in the output, the
 ID and semantics values \rfcmust\ be provided as usual. From version 1.1 of this standard,
 services \rfcmay\  provide values in other fields or leave them null (as was required in 1.0).
 
-For example, if an ID value is unrecognized by the service, it would normally provide the 
-minimum output: the input value for the ID, \verb|#this| for semantics, and an error 
-message. If a service did recognise the input ID and would normally create a download link, 
-but generating the access\_url failed, the service could include the usual content\_type, 
+For example, if an ID value is unrecognized by the service, it would normally provide the
+minimum output: the input value for the ID, \verb|#this| for semantics, and an error
+message. If a service did recognise the input ID and would normally create a download link,
+but generating the access\_url failed, the service could include the usual content\_type,
 content\_length, and description along with the ID, semantics, and error\_message.
 
 
@@ -621,10 +621,6 @@ The core DataLink vocabulary defines a special term for
 the concept of {\em this\/};
 this term is used to describe links available for the retrieval of the
 file(s) making up what ID references.
-
-Since NULL values are not permitted in the semantics column, when only
-an error\_message is supplied its value \rfcshould\ be the most appropriate
-for the link the service was trying to generate.
 
 For concepts outside the core DataLink vocabulary, the full concept URI
 \rfcmust\ be given.  It \rfcshould\ resolve to a human-readable document
@@ -688,14 +684,14 @@ DataLink.
 \subsubsection{local\_semantics}
 \label{sec:localSemantics}
 
-The local\_semantics column allows for identification of corresponding rows for 
-different IDs in the same DataLink service where the combination of semantics, 
-content\_type and content\_qualifier is not sufficient to identify them. 
-It contains a service specific vocabulary. An example is a service delivering 
-spectral cubes derived from the same observation, with both continuum cubes 
-and line cubes. The combination of ``semantics=\#derived'', 
-``content\_type=application/fits'' and ``content\_qualifier=cube'' 
-is insufficient to identify the various continuum or line cubes. 
+The local\_semantics column allows for identification of corresponding rows for
+different IDs in the same DataLink service where the combination of semantics,
+content\_type and content\_qualifier is not sufficient to identify them.
+It contains a service specific vocabulary. An example is a service delivering
+spectral cubes derived from the same observation, with both continuum cubes
+and line cubes. The combination of ``semantics=\#derived'',
+``content\_type=application/fits'' and ``content\_qualifier=cube''
+is insufficient to identify the various continuum or line cubes.
 The local\_semantics column allows this needed information to be provided.
 
 
@@ -969,19 +965,19 @@ the service invocation.
 
 For user-specified input PARAMs the value attribute is empty (\attval{value}{})
 and the user supplies the value(s). The PARAM specifies the type of value required via
-the datatype, arraysize, and xtype attributes; this may be augmented further by the ucd, 
- units and utypes\footnote{An example of utype usage for service 
+the datatype, arraysize, and xtype attributes; this may be augmented further by the ucd,
+ units and utypes\footnote{An example of utype usage for service
 parameters is described in section 3.4 of the SODA specification} attributes
 and a child DESCRIPTION element. To allow for expressive, usable user
-interfaces, operators SHOULD indicate useful ranges of parameters in MIN and MAX children 
+interfaces, operators SHOULD indicate useful ranges of parameters in MIN and MAX children
 or, for enumerated parameters, indicate the valid values in OPTIONS  in case
 these values cannot be inferred from relevant metadata retrieved
 before the service descriptor discovery. In general, services
-may have parameters of this type that are optional or required and this distinction is 
-not currently described; services \rfcshould\ use a child DESCRIPTION element to document any 
-requirements. Clients should assume that these user-specified parameters are optional, but 
-that specifying some of them may be necessary to have the service do something useful. 
-Services \rfcshould\ respond with an informative error message if the input is not adequate to 
+may have parameters of this type that are optional or required and this distinction is
+not currently described; services \rfcshould\ use a child DESCRIPTION element to document any
+requirements. Clients should assume that these user-specified parameters are optional, but
+that specifying some of them may be necessary to have the service do something useful.
+Services \rfcshould\ respond with an informative error message if the input is not adequate to
 perform the operations(s).
 
 \subsection{Example: Service Descriptor for the \blinks\ Capability}
@@ -1249,7 +1245,7 @@ to be operationally insignificant.
 \label{sec:selfDescribing}
 
 A service may include a service descriptor that describes itself with
-its normal output. 
+its normal output.
 In that case the utype ``adhoc:this'' indicates the self-describing
 nature of the service descriptor.
 This convention makes finding the self-description unambiguous in
@@ -1266,7 +1262,7 @@ description of both standard and custom features.
 For backward compatibility with DataLink 1.0 and SIA 2.0, client software
 conforming to the present recommendation should also treat elements of
 the form \verb|<RESOURCE type="meta" utype="adhoc:service" name="this"/>|
-as self-descriptions, equivalent to 
+as self-descriptions, equivalent to
 \verb|<RESOURCE type="meta" utype="adhoc:this" name=""/>|.
 A conforming client should treat the provision of more than one
 self-description \texttt{<RESOURCE>} element as an error, except that if a
@@ -1336,22 +1332,22 @@ redirects to make old URLs work when service deployment changes).
 \subsection{DataLink-1.1}
 
 \begin{itemize}
-\item allow optional columns to contain values when the row (link) has an error\_message 
+\item allow optional columns to contain values when the row (link) has an error\_message
 (see Section \ref{sec:errorMessage})
-\item added optional local\_semantics to identify corresponding rows 
+\item added optional local\_semantics to identify corresponding rows
 	for different IDs in the same service (see Section \ref{sec:localSemantics})
-\item relax content-type usage to allow any valid VOTable MIME type (see Section 
+\item relax content-type usage to allow any valid VOTable MIME type (see Section
   \ref{sec:successfulRequests})
-\item INFO element with standardID mandatory in \blinks\ response (see Section 
+\item INFO element with standardID mandatory in \blinks\ response (see Section
   \ref{sec:output})
 \item added optional content\_qualifier to describe link target content with terms from
 the product-type vocabulary (see Section \ref{sec:contentQualifier})
 \item added optional link\_auth and link\_authorized to signal whether authentication
-is necessary to use the link (see Sections \ref{sec:linkAuth} and 
+is necessary to use the link (see Sections \ref{sec:linkAuth} and
 \ref{sec:linkAuthorized})
-\item clarified use of multiple ID values and possible OVERFLOW (see Section 
+\item clarified use of multiple ID values and possible OVERFLOW (see Section
   \ref{sec:resourceId})
-\item clarified use of utype for self-describing service descriptors(see Section 
+\item clarified use of utype for self-describing service descriptors(see Section
   \ref{sec:selfDescribing})
 \item clarified use of semantics (see Section \ref{sect:semantics})
 \item generalize by adding use cases for links to content other than data files
@@ -1359,11 +1355,11 @@ is necessary to use the link (see Sections \ref{sec:linkAuth} and
 \item added using LINK to convey when datalink request URL is in a table column
   (see Section \ref{sec:columnsUrl})
 \item service descriptors can include a contentType param to describe service
-output and should include a name and description (see Sections \ref{sec:serviceResources} 
+output and should include a name and description (see Sections \ref{sec:serviceResources}
 and \ref{sec:descParams})
 \item service descriptors can include exampleURL param(s) with working example
 and description (see Section \ref{sec:descParams})
-\item VOSI-availability and VOSI-capabilities endpoints are now optional (see 
+\item VOSI-availability and VOSI-capabilities endpoints are now optional (see
   Section \ref{sec:vosi})
 \end{itemize}
 


### PR DESCRIPTION
Excuse the trailing whitespace changes, but then the other changes should be about as meaning-preserving.

One thing that may look meaning-changing: I'm dropping a paragraph on semantics of error_message-carrying rows.  But that, I claim, is discussed exhaustively above.

I have, in addition, a few less meaning-preserving suggestions; see
https://wiki.ivoa.net/twiki/bin/view/IVOA/DataLink11RFC#Community%20Comment%20by%20Markus%20Deml